### PR TITLE
Add library to issue request to the Scratch REST API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,7 @@ published to the live site ASAP - Rían</li>
 @Mach1982
 @ThatProgrammerRian
 @calucifier
-@Sumotoad987
 @richardbeattie
+## Noncontributors
+@SumoToad987
+

--- a/README.md
+++ b/README.md
@@ -9,10 +9,16 @@ Full Contributors List below
 
 Features in progress:
 <ul>
-<li>Ninjas Section</li>
-<li>News section</li>
+<li>CMS</li>
+<li>Style</li>
 <li>Resources</li>
 </ul>
+
+##Want to get involved
+
+This site is open source so anyone can help make it better if have a feature you want to see in the sight, have found a bug or just think the style could be better in some areas download a copy of this repo and edit it. 
+
+Or if you want to help out but just don't know what to do contact one of the developers and they will be deligheted for any extra help.
 
 ##Contributors' Notice
 <ul>
@@ -37,6 +43,4 @@ published to the live site ASAP - Rían</li>
 @ThatProgrammerRian
 @calucifier
 @richardbeattie
-## Noncontributors
-@SumoToad987
 

--- a/includes/api/scratch-test.php
+++ b/includes/api/scratch-test.php
@@ -1,0 +1,32 @@
+<?php
+  /**
+   * Functional tests for the Scratch API helper classes.
+   */
+  require_once('scratch.php');
+
+  // ScratchProjects Tests
+  assert_options(ASSERT_BAIL, 1);
+
+  $projects = ScratchProjects::getUserShared('kyla_errity');
+  assert(
+    count($projects) > 0,
+    'Check that more than one projects are returned.'
+  );
+  assert(
+    !empty($projects[0]['id']),
+    'Check that a project ID is returned.'
+  );
+
+  $project = ScratchProjects::getUserProjectById('kyla_errity', '101499178');
+  assert(
+    $project['id'] === 101499178,
+    'Check that the returned project ID equals 101499178.');
+
+  $response = ScratchProjects::getUserFavorites('kdsjhfksjdhfakfhsakdjfh');
+  assert(
+    $response['HttpCode'] === 404,
+    'Check that the response code for the invalid user is 404.'
+  );
+
+  echo('All Scratch API tests passed!')
+?>

--- a/includes/api/scratch.php
+++ b/includes/api/scratch.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Set of Helpers to retrieve Scratch resources via its REST API.
+ *
+ * TODO(spastorelli): Add helper classes for other API resources.
+ *
+ * API Documentation:
+ *    https://github.com/LLK/scratch-rest-api/wiki
+ */
+
+/**
+ * Helper class for the Projects resource.
+ *
+ * API Resource Documentation:
+ *    https://github.com/LLK/scratch-rest-api/wiki/Projects
+ */
+class ScratchProjects
+{
+  /**
+   * Returns list of projects shared by the $user.
+   *
+   * @param string $user The nickname of the user.
+   */
+  public static function getUserShared($user) {
+    $resource = array('users', $user, 'projects');
+    return ScratchRestApiRequest::send($resource);
+  }
+
+  /**
+   * Returns the project shared by the $user using its $projectId.
+   *
+   * @param string $user The nickname of the user.
+   * @param string $projectId The ID of the project.
+   */
+  public static function getUserProjectById($user, $projectId) {
+    $resource = array('users', $user, 'projects', $projectId);
+    return ScratchRestApiRequest::send($resource);
+  }
+
+  /**
+   * Returns a list of the $user favorites projects.
+   *
+   * @param string $user The nickname of the user.
+   */
+  public static function getUserFavorites($user) {
+    $resource = array('users', $user, 'favorites');
+    return ScratchRestApiRequest::send($resource);
+  }
+
+}
+
+/**
+ * Simple wrapper around cURL to issue GET requests to Scratch REST API.
+ *
+ * Not intended to be used directly; Resources Helper classes should be used
+ * instead.
+ */
+class ScratchRestApiRequest
+{
+  const BaseUrl = 'https://api.scratch.mit.edu';
+
+  /**
+   *  Creates the API resource URL from the resource path items.
+   *
+   * @param array $resourceItems An array containing the items of the resource
+   *      path.
+   * @return string The resource URL.
+   */
+  private static function _createResourceUrl(&$resourceItems) {
+    $resourceUrl .= ScratchRestApiRequest::BaseUrl;
+    foreach ($resourceItems as $i => $item) {
+      $resourceUrl .= '/' . $item;
+    }
+    return $resourceUrl;
+  }
+
+  /**
+   * Returns an initialized cURL request object.
+   *
+   * @param string $resourceUrl The API resource url.
+   * @return mixed The initialized request object.
+   */
+  private static function _prepareHttpRequest($resourceUrl) {
+    $request = curl_init();
+    curl_setopt($request, CURLOPT_URL, $resourceUrl);
+    curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
+
+    return $request;
+  }
+
+  /**
+   * Issues an API request to the specific resource path.
+   *
+   * @param array $resourceItems An array containing the items of the resource
+   *      path.
+   * @return array An associative array containing the API resource response
+   *      data.
+   */
+  public static function send(&$resourceItems) {
+    $resourceUrl = ScratchRestApiRequest::_createResourceUrl($resourceItems);
+    $request = ScratchRestApiRequest::_prepareHttpRequest($resourceUrl);
+    $response = curl_exec($request);
+    $code = curl_getinfo($request, CURLINFO_HTTP_CODE);
+    curl_close($request);
+
+    $data = json_decode($response, true);
+    if ($code !== 200) {
+      $errorDetails = array('HttpCode' => $code);
+      $data = array_merge($data, $errorDetails);
+    }
+    return $data;
+  }
+
+}
+?>


### PR DESCRIPTION
I've written this simple library to interact with [Scratch REST API](https://github.com/LLK/scratch-rest-api/wiki). Only done the Projects resource, but that should help with Issue #4.

There are examples of use in `scratch-test.php`. I will be adding a test page (ie `ninjas-scratch-projects.php`) to my forked repo to show how it could be used on the LPTC site. 

@richardbeattie, @ThatProgrammerRian, @calucifer: Let me know if you would be interested by this pull request.